### PR TITLE
[FEAT] 멋사 FE 9주차 과제

### DIFF
--- a/front/FEweek09/src/apis/api.js
+++ b/front/FEweek09/src/apis/api.js
@@ -2,6 +2,7 @@ import axios from "axios";
 
 const API_BASE_URL = "http://127.0.0.1:8000";
 
+// 브라우저 localStorage에 저장해둔 Access Token과 username를 제거
 export const clearAuthStorage = () => {
   localStorage.removeItem("accessToken");
   localStorage.removeItem("username");
@@ -26,6 +27,7 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
+// 토큰 재발급 진행 상태를 저장하는 변수
 let refreshPromise = null;
 
 api.interceptors.response.use(
@@ -33,6 +35,9 @@ api.interceptors.response.use(
   async (error) => {
     const originalRequest = error.config;
 
+    // 401이 아니거나,
+    // 이미 재시도한 요청이거나,
+    // 로그인 요청에서 발생한 에러일 경우 재발급하지 않고 에러 처리
     if (
       error.response?.status !== 401 ||
       originalRequest?._retry ||
@@ -41,20 +46,25 @@ api.interceptors.response.use(
       return Promise.reject(error);
     }
 
+    // 토큰 재발급 요청을 이미 시도했음을 표시(동일한 요청의 반복 방지)
     originalRequest._retry = true;
 
     try {
       if (!refreshPromise) {
         refreshPromise = axios
+          // 쿠키에 저장된 Refresh Token으로 서버에 새 Access Token을 요청
           .post(`${API_BASE_URL}/login/refresh/`, {}, { withCredentials: true })
           .then((response) => {
+            // 서버 응답에서 새 Access Token을 가져옴
             const newAccessToken =
               response.data.accessToken ?? response.data.access;
 
+            // 새 Access Token을 브라우저 localStorage에 저장
             localStorage.setItem("accessToken", newAccessToken);
             return newAccessToken;
           })
           .finally(() => {
+            // 토큰 재발급이 완료되었으므로 진행 상태 초기화
             refreshPromise = null;
           });
       }
@@ -64,6 +74,7 @@ api.interceptors.response.use(
 
       return api(originalRequest);
     } catch (refreshError) {
+      // 토큰 재발급에 실패하면 브라우저 localStorage에 저장된 정보를 삭제하고 로그인 화면으로 이동
       clearAuthStorage();
       window.location.replace("/login");
       return Promise.reject(refreshError);

--- a/front/FEweek09/src/apis/api.js
+++ b/front/FEweek09/src/apis/api.js
@@ -70,8 +70,11 @@ api.interceptors.response.use(
       }
 
       const newAccessToken = await refreshPromise;
+
+      // 재발급 받은 Access Token으로 기존 인증 정보를 업데이트
       originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
 
+      // 새 Access Token을 사용해 실패한 기존 요청을 다시 전송
       return api(originalRequest);
     } catch (refreshError) {
       // 토큰 재발급에 실패하면 브라우저 localStorage에 저장된 정보를 삭제하고 로그인 화면으로 이동

--- a/front/FEweek09/src/apis/api.js
+++ b/front/FEweek09/src/apis/api.js
@@ -7,14 +7,18 @@ export const clearAuthStorage = () => {
   localStorage.removeItem("username");
 };
 
+// API 요청에 공통으로 적용되는 기본 설정을 포함한 Axios 인스턴스
 const api = axios.create({
-  baseURL: API_BASE_URL,
-  withCredentials: true,
+  baseURL: API_BASE_URL, // 요청마다 전체 서버 주소를 작성할 필요 없음
+  withCredentials: true, // 요청마다 브라우저 쿠키를 함께 전송
 });
 
+// 서버로 API 요청을 보내기 전 실행
 api.interceptors.request.use((config) => {
+  // 저장된 Access Token을 가져옴
   const accessToken = localStorage.getItem("accessToken");
 
+  // Access Token이 있으면 API 요청 헤더에 추가
   if (accessToken) {
     config.headers.Authorization = `Bearer ${accessToken}`;
   }

--- a/front/FEweek09/src/components/Header.jsx
+++ b/front/FEweek09/src/components/Header.jsx
@@ -28,14 +28,19 @@ const Header = ({ title, description, button }) => {
 
   const handleLogout = async () => {
     try {
+      // ① 서버에 로그아웃 요청(POST)
       await api.post("/logout/");
     } catch (error) {
       console.error("로그아웃 요청 실패:", error);
     } finally {
+      // ② 브라우저 localStorage에 저장된 정보 삭제
       clearAuthStorage();
 
+      // ③ 로그아웃 후 CommentPage(/)로 이동
       alert("로그아웃되었습니다.");
       navigate("/");
+
+      // ④ 화면을 새로고침해 변경된 로그인 상태를 반영
       window.location.reload();
     }
   };

--- a/front/FEweek09/src/pages/LoginPage.jsx
+++ b/front/FEweek09/src/pages/LoginPage.jsx
@@ -19,24 +19,31 @@ const LoginPage = () => {
     try {
       setIsLoading(true);
 
+      // ① 서버에 로그인 요청(POST)
       const response = await axios.post(
         "http://127.0.0.1:8000/login/",
         { username, password },
-        { withCredentials: true },
+        { withCredentials: true }, // 쿠키에 저장된 인증 정보도 함께 전송
       );
 
+      // ② 서버의 응답에서 Access Token 추출
       const accessToken = response.data.accessToken ?? response.data.access;
 
+      // 토큰이 없으면 로그인을 처리하지 않음
       if (!accessToken) {
         throw new Error("Access Token이 없습니다.");
       }
 
+      // ③ Access Token을 브라우저 localStorage에 저장
       localStorage.setItem("accessToken", accessToken);
+
+      // ④ username도 브라우저 localStorage에 저장
       localStorage.setItem(
         "username",
         response.data.username ?? username.trim(),
       );
 
+      // ⑤ 로그인 성공 후 CommentPage(/)로 이동
       alert("로그인에 성공했어요!");
       navigate("/");
     } catch (error) {


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)를 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #이슈번호 를 적어주세요. -->
closed #40 

## ✨ 과제 내용
<!-- 구현한 부분에 대해 설명해주세요. -->

**실습 코드 주석 달기 (JWT 인증 흐름 이해)**

- `LoginPage.jsx` 에서 로그인 요청과 Access Token을 저장하는 과정에 주석 작성
- `src/apis/api.js` 에서 Access Token을 모든 요청에 자동으로 포함하는 과정에 주석 작성
- Access Token 만료 시 새로운 토큰을 발급받고 저장하는 과정에 주석 작성
- 재발급된 Access Token으로 기존 요청을 다시 전송하는 과정에 주석 작성
- `Header.jsx` 에서 로그아웃 요청과 인증 정보 삭제 과정에 주석 작성

## 📷 스크린샷 (선택)
<!-- 필요 시 스크린샷을 첨부해주세요. -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
